### PR TITLE
Fix #3 replace concat by push

### DIFF
--- a/packages/webpack-step/src/configTypescript.ts
+++ b/packages/webpack-step/src/configTypescript.ts
@@ -8,7 +8,7 @@ export interface IWebpackConfigTypescript extends IWebpackConfigBase {
 
 export function getTypescriptConfig(config: IWebpackConfigTypescript): Configuration {
   const webpackConfig = getBaseConfig(config)
-  webpackConfig.resolve.extensions.concat(['.tsx', '.ts'])
+  webpackConfig.resolve.extensions.push('.tsx', '.ts')
   webpackConfig.module.rules.push({
     test: /\.tsx?$/,
     use: [


### PR DESCRIPTION
The concat() method is used to merge two or more arrays. This method does not change the existing arrays, but instead returns a new array.

(source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat)